### PR TITLE
Port brand-agnostic work from JARVIS into EVA

### DIFF
--- a/LED-WIRING.md
+++ b/LED-WIRING.md
@@ -1,0 +1,102 @@
+# LED strip wiring — Govee H6190 on the Pi
+
+Analog RGB, common anode. **12V, 1.5A, 18W.** Not addressable — one colour
+across the whole strip, three PWM channels.
+
+Confirmed from the original Arduino sketch (`Source/ArduinoLED/ArduinoLED.ino`),
+which used `analogWrite` on three separate pins: red 11, green 10, blue 9.
+
+## Parts
+
+| Qty | Part | Note |
+|---|---|---|
+| 3 | P30N06LE N-channel MOSFET | logic-level. TO-220 |
+| 3 | 220Ω resistor | gate series |
+| 3 | 10kΩ resistor | gate pull-down — **do not skip** |
+| 1 | 12V PSU, 2A+ | separate from the Pi |
+
+**The 10kΩ pull-downs matter.** Pi GPIOs float during boot until something
+configures them. Without a pull-down the gates drift and the strip flickers or
+comes on full white every time the car starts, until the app loads.
+
+## Pins
+
+| Colour | GPIO | Physical pin |
+|---|---|---|
+| Red | 12 | 32 |
+| Green | 13 | 33 |
+| Blue | 19 | 35 |
+| Ground | — | 34 (or any GND) |
+
+GPIO 18 is deliberately avoided: `dtparam=audio=on` is set and onboard analog
+audio shares that PWM hardware. GPIO 2 and 3 are the IMU's I2C bus — leave alone.
+
+## Circuit
+
+One of these per colour. Three identical copies.
+
+```
+   Pi GPIO 12 ──[220Ω]──┬──────────► GATE ┐
+   (pin 32)             │                 │
+                      [10kΩ]              │   P30N06LE
+                        │                 │   (TO-220)
+   Pi GND ──────────────┴─────────────► SOURCE ┘
+   (pin 34)             │                 │
+                        │              DRAIN
+                        │                 │
+                        │                 ▼
+                        │        ┌─────────────────┐
+                        │        │  LED STRIP      │
+                        │        │  R  G  B  +12V  │
+                        │        └──┬──┬──┬────┬───┘
+                        │           │  │  │    │
+     drain of R MOSFET ─────────────┘  │  │    │
+     drain of G MOSFET ────────────────┘  │    │
+     drain of B MOSFET ───────────────────┘    │
+                        │                      │
+   12V PSU  (+) ─────────────────────────────-─┘
+   12V PSU  (−) ────────┴─ COMMON GROUND
+```
+
+**Common ground is mandatory.** Pi GND and PSU − must be tied together or the
+MOSFETs have no reference and won't switch reliably.
+
+**Never feed 12V into the Pi.** The strip's supply touches only the strip and
+the MOSFET drains. This Pi already browns out under GPU load on a marginal
+converter; 18W of LEDs on its rail would be much worse.
+
+## MOSFET pinout
+
+TO-220 is conventionally **Gate – Drain – Source** left to right, front facing,
+with the metal tab tied to Drain. **Verify your specific part before powering
+up** — buzz it with a multimeter or check its own markings. Reversed pins is how
+you release the smoke.
+
+## Gate drive caveat
+
+The P30N06LE's 0.047Ω R<sub>DS(on)</sub> is specified at **Vgs = 5V**. The
+Arduino drove it at 5V; the Pi only outputs **3.3V**, so it runs partially
+enhanced with higher resistance.
+
+At this current it does not matter. Each channel carries roughly 0.5A, so even
+at several times the rated resistance the dissipation is well under 0.1W. This
+would only be a problem at much higher currents.
+
+## Software
+
+`Source/lights.py` holds the PWM. It is spawned by `main.js` shortly after boot,
+reads `{"r":0-255,"g":0-255,"b":0-255}` JSON lines on stdin, and is driven from
+the Lights tab sliders.
+
+Backend is `pigpio` when its daemon is running, otherwise `gpiozero`. The Lights
+tab shows which is active. pigpio's PWM is DMA-timed and will not flicker under
+load; gpiozero generates it from a Python thread, which can jitter on a
+throttled Pi. To use pigpio:
+
+```
+sudo systemctl enable --now pigpiod
+```
+
+Colour is persisted to `~/.eva-config.json` on every change and restored at
+boot, so the strip returns to what it was set to after an ignition cycle rather
+than defaulting to off.

--- a/Source/branding.js
+++ b/Source/branding.js
@@ -1,0 +1,67 @@
+/* Branding: which sub-version of EVA this head unit identifies as.
+ *
+ * JARVIS is Morgane's build. It is not a fork of the codebase - it is the same
+ * application wearing a different name and palette, so features land once and
+ * both cars get them. Everything here is presentation only.
+ *
+ * Loaded from <head> before first paint, alongside themeBoot.js, so the brand
+ * attribute is set before any CSS is applied and the name never flickers.
+ */
+const BRANDS = {
+  eva: {
+    name: 'EVA',
+    greeting: 'Hello, Alex',
+    /* Alex's car: silver over black, teal instrument cluster */
+    palette: 'teal'
+  },
+  jarvis: {
+    name: 'JARVIS',
+    greeting: 'Hello, Morgane',
+    /* Morgane's car: white over beige, so the UI runs warm rather than cool */
+    palette: 'amber'
+  }
+};
+
+/* The brand is runtime state, not a code constant: this head unit belongs to
+   Alex and is only lent out, so it must fall back to EVA on its own rather
+   than needing an edit to change hands. The main process reads it from
+   ~/.eva-config.json and passes it on the URL, the same way the theme is
+   handed over, so it is set before first paint. Absent config means EVA. */
+function resolveBrand() {
+  try {
+    const p = new URLSearchParams(window.location.search).get('brand');
+    if (p && BRANDS[p]) return p;
+  } catch (e) {
+    /* fall through */
+  }
+  return 'eva';
+}
+
+const ACTIVE_BRAND = resolveBrand();
+
+const BRAND = BRANDS[ACTIVE_BRAND] || BRANDS.eva;
+
+(function applyBrand() {
+  document.documentElement.setAttribute('data-brand', ACTIVE_BRAND);
+  /* accent is independent of brand - it retints the highlight colour only */
+  try {
+    const a = new URLSearchParams(window.location.search).get('accent');
+    if (a === 'purple' || a === 'green') document.documentElement.setAttribute('data-accent', a);
+  } catch (e) {
+    /* no accent override */
+  }
+  /* The DOM may not exist yet when this runs from <head>; fill in the text
+     nodes once it does. */
+  const paint = () => {
+    document.querySelectorAll('[data-brand-name]').forEach((el) => {
+      el.textContent = BRAND.name;
+    });
+    document.querySelectorAll('[data-brand-greeting]').forEach((el) => {
+      el.textContent = BRAND.greeting;
+    });
+  };
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', paint);
+  else paint();
+})();
+
+if (typeof module !== 'undefined' && module.exports) module.exports = { BRANDS, ACTIVE_BRAND, BRAND };

--- a/Source/entry.html
+++ b/Source/entry.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" href="styleEntry.css">
     <script src="daylight.js"></script>
     <script src="themeBoot.js"></script>
+    <script src="branding.js"></script>
 </head>
 <body>
     <div class="prompt">Enter Code</div>

--- a/Source/gui.html
+++ b/Source/gui.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="daylight.js"></script>
     <script src="themeBoot.js"></script>
+    <script src="branding.js"></script>
   </head>
   <body onload="initTabs()">
 
@@ -20,7 +21,7 @@
         Lights
       </button>
       <button class="tablinks" onclick="openTab(event, 'Music')">
-        <svg viewBox="0 0 24 24"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+        <svg viewBox="0 0 24 24"><rect x="4" y="2.5" width="16" height="19" rx="2.6"/><circle cx="12" cy="14.5" r="4.2"/><circle cx="12" cy="14.5" r="1.4"/><circle cx="12" cy="6.5" r="1.6"/></svg>
         Music
       </button>
       <button class="tablinks" onclick="openTab(event, 'Logs')">
@@ -28,13 +29,13 @@
         Logs
       </button>
       <button class="tablinks" onclick="openTab(event, 'Track')">
-        <svg viewBox="0 0 24 24"><path d="M4 18a8 8 0 1 1 16 0"/><path d="m12 14 4-4"/><circle cx="12" cy="18" r="1.4"/></svg>
+        <svg viewBox="0 0 24 24"><path d="M3.5 18a8.5 8.5 0 0 1 17 0"/><path d="M12 18 16.6 12.4" stroke-width="2"/><circle cx="12" cy="18" r="1.5" fill="currentColor" stroke="none"/><path d="M4.9 13.6l1.1.5M7.6 9.9l.9.9M12 8.2v1.4M16.4 9.9l-.9.9M19.1 13.6l-1.1.5" opacity=".7"/></svg>
         Track
       </button>
     </div>
 
     <div class="statusbar">
-      <div class="brand">EVA</div>
+      <div class="brand" data-brand-name>EVA</div>
       <div class="right">
         <div class="pill off" id="gps-pill">GPS</div>
         <button class="pill off" id="obd-pill" onclick="openDiagnostics()">OBD</button>
@@ -57,7 +58,7 @@
     </div>
 
     <div id="Lights" class="tabcontent">
-      <div class="panel-title">Interior Lighting</div>
+      <div class="panel-title">Interior Lighting <span class="badge" id="lights-backend">&mdash;</span></div>
       <div class="lights-layout">
         <div class="colorbox"></div>
         <div class="slidecontainer">
@@ -102,6 +103,11 @@
           <button class="ghost-btn" onclick="newFolder()">+ Folder</button>
           <button class="primary-btn" onclick="openNewEntry()"><i class="rec-dot"></i> New Entry</button>
         </div>
+      </div>
+
+      <div class="storage-bar" id="storage-bar">
+        <div class="storage-track"><i id="storage-fill"></i></div>
+        <div class="storage-text" id="storage-text">&mdash;</div>
       </div>
 
       <div class="rec-banner" id="rec-banner">
@@ -172,6 +178,25 @@
             </div>
             <div class="scale-ends"><span>1 &middot; Soft</span><span>Firm &middot; 32</span></div>
           </div>
+        </div>
+
+        <div class="settings-section">
+          <div class="section-title">Vehicle Profile <span class="badge" id="brand-state">EVA</span></div>
+          <div class="theme-picker">
+            <button class="theme-option" data-brand-opt="eva" onclick="setBrand('eva')">EVA</button>
+            <button class="theme-option" data-brand-opt="jarvis" onclick="setBrand('jarvis')">JARVIS</button>
+          </div>
+          <p class="chart-note">Switches the name and colour scheme for whoever's car this unit is in. Reloads on change. Defaults back to EVA if the setting is ever cleared.</p>
+        </div>
+
+        <div class="settings-section">
+          <div class="section-title">Accent Colour</div>
+          <div class="theme-picker">
+            <button class="theme-option" data-accent-opt="default" onclick="setAccent('default')">Default</button>
+            <button class="theme-option" data-accent-opt="purple" onclick="setAccent('purple')">Purple</button>
+            <button class="theme-option" data-accent-opt="green" onclick="setAccent('green')">Green</button>
+          </div>
+          <p class="chart-note">Retints highlights, the g-force gauge and the active tab. Reloads on change.</p>
         </div>
 
         <div class="settings-section">

--- a/Source/lights.py
+++ b/Source/lights.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""RGB LED strip control over GPIO PWM.
+
+Replaces the original Arduino-over-serial path, which targeted a Windows COM
+port and was never wired to the app.
+
+Reads one JSON object per line on stdin: {"r":0-255,"g":0-255,"b":0-255}
+and optionally {"brightness":0-100}. Writes status lines as JSON on stdout.
+
+The strip is a 12V common-anode analog RGB (Govee H6190, 18W / 1.5A). The Pi
+cannot drive it directly - each colour switches through a logic-level N-channel
+MOSFET, with the 12V coming from its own supply. See LED-WIRING.md.
+
+pigpio is preferred over gpiozero's default backend because its PWM is
+DMA-timed rather than generated in a Python thread. This Pi runs throttled at
+600MHz under load, where software PWM visibly flickers.
+"""
+import json
+import sys
+import os
+import atexit
+import contextlib
+
+# Chosen to avoid GPIO 18/19: dtparam=audio=on is set, and onboard analog audio
+# shares that PWM hardware. GPIO 2/3 are the IMU's I2C bus.
+PINS = {'r': 12, 'g': 13, 'b': 19}
+PWM_HZ = 800          # above flicker perception, below MOSFET switching losses
+
+state = {'r': 0, 'g': 0, 'b': 0, 'brightness': 100}
+backend = None
+_pi = None
+_leds = {}
+
+
+def emit(**kw):
+    sys.stdout.write(json.dumps(kw) + '\n')
+    sys.stdout.flush()
+
+
+def setup():
+    """Try pigpio first, fall back to gpiozero. Either is fine for LEDs; only
+       the flicker behaviour under load differs."""
+    global backend, _pi, _leds
+    try:
+        import pigpio
+        # pigpio prints a multi-line banner straight to stdout when the daemon
+        # is absent, which corrupts the JSON stream this process speaks. Mute
+        # both streams for the duration of the probe.
+        with open(os.devnull, 'w') as null:
+            with contextlib.redirect_stdout(null), contextlib.redirect_stderr(null):
+                pi = pigpio.pi()
+        if pi.connected:
+            _pi = pi
+            for pin in PINS.values():
+                pi.set_PWM_frequency(pin, PWM_HZ)
+                pi.set_PWM_range(pin, 255)
+                pi.set_PWM_dutycycle(pin, 0)
+            backend = 'pigpio'
+            return
+        pi.stop()
+    except Exception:
+        pass
+
+    try:
+        from gpiozero import PWMLED
+        for key, pin in PINS.items():
+            _leds[key] = PWMLED(pin, frequency=PWM_HZ)
+        backend = 'gpiozero'
+    except Exception as exc:
+        backend = None
+        emit(event='error', message=f'no GPIO backend available: {exc}')
+
+
+def apply():
+    if backend is None:
+        return
+    scale = max(0, min(100, state['brightness'])) / 100.0
+    for key, pin in PINS.items():
+        value = max(0, min(255, int(state[key]))) * scale
+        if backend == 'pigpio':
+            _pi.set_PWM_dutycycle(pin, int(round(value)))
+        else:
+            _leds[key].value = value / 255.0
+
+
+def shutdown():
+    """Leave the strip dark rather than latched on if the process dies."""
+    try:
+        if backend == 'pigpio' and _pi is not None:
+            for pin in PINS.values():
+                _pi.set_PWM_dutycycle(pin, 0)
+            _pi.stop()
+        elif backend == 'gpiozero':
+            for led in _leds.values():
+                led.off()
+                led.close()
+    except Exception:
+        pass
+
+
+atexit.register(shutdown)
+
+setup()
+emit(event='ready', backend=backend, pins=PINS)
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except ValueError:
+        continue
+    for key in ('r', 'g', 'b', 'brightness'):
+        if key in msg:
+            try:
+                state[key] = int(msg[key])
+            except (TypeError, ValueError):
+                pass
+    apply()
+    emit(event='state', **state)

--- a/Source/logs.js
+++ b/Source/logs.js
@@ -1,35 +1,42 @@
 const THUMBS = {
   testing: {
     label: 'Testing',
-    accent: '#3fd0b0',
-    svg: '<path d="M26 6v12L14 34h36L38 18V6"/><path d="M22 6h20"/><path d="M20 26h24"/><circle cx="28" cy="29" r="1.6"/><circle cx="37" cy="30" r="1.2"/>'
+    accent: '#e8503a',
+    svg: '<rect x="5" y="5" width="54" height="29" rx="2.5" opacity=".55"/><path d="M5 19.5h54M23 5v29M41 5v29" opacity=".25"/><path d="M8 24c5 0 5-11 9-11s4 15 8 15 5-17 9-17 5 12 9 12 4-8 8-8 4 6 5 6" stroke-width="2"/>'
   },
   cruising: {
     label: 'Cruising',
-    accent: '#b7babc',
-    svg: '<path d="M4 32h56"/><path d="M24 32 30 10h4l6 22"/><path d="M31 14v3M31 21v3M31 28v2"/><circle cx="48" cy="14" r="6"/>'
+    accent: '#c9a227',
+    svg: '<path d="M4 34h56" opacity=".45"/><path d="M20 34 27 12h10l7 22"/><path d="M32 15v3.5M32 22v3.5M32 29v2.5" opacity=".7"/><path d="M8 26h7M49 26h7" opacity=".5"/><circle cx="52" cy="12" r="4.5"/>'
   },
   performance: {
     label: 'Performance',
-    accent: '#ff7a33',
-    svg: '<circle cx="32" cy="22" r="13"/><path d="M32 22 40 15"/><path d="M32 5v4"/><path d="M26 5h12"/><path d="M19 12l-3-3M45 12l3-3"/>'
+    accent: '#e8503a',
+    svg: '<path d="M4 34h56" opacity=".45"/><path d="M12 30a20 20 0 0 1 40 0"/><path d="M32 30 43 17" stroke-width="2.2"/><circle cx="32" cy="30" r="2.4" fill="currentColor" stroke="none"/><path d="M14 24l2.5 1M20 17l2 2M32 13v3M44 17l-2 2M50 24l-2.5 1" opacity=".7"/>'
   },
   canyon: {
     label: 'Canyon',
-    accent: '#2a8c78',
-    svg: '<path d="M2 34 20 10l10 13 8-9 22 20z"/><path d="M22 34c4-6 12-4 12-10s8-6 10-2"/>'
+    accent: '#4f8f6b',
+    svg: '<path d="M4 34h56" opacity=".4"/><path d="M28 34 44 11l7 9 5-5 8 19Z" opacity=".45"/><path d="M0 34 16 9l11 14 6-7 13 18Z" stroke-width="1.9"/><path d="M11 17.5h9" opacity=".55"/>'
   },
   track: {
     label: 'Track Day',
-    accent: '#e9edee',
-    svg: '<path d="M14 34V6"/><path d="M14 8h34v16H14z"/><path d="M14 8h8.5v5.3H14zM31 8h8.5v5.3H31zM22.5 13.3H31v5.3h-8.5zM39.5 13.3H48v5.3h-8.5zM14 18.6h8.5V24H14zM31 18.6h8.5V24H31z" fill="currentColor" stroke="none" opacity="0.55"/>'
+    /* var(--numeral) rather than a fixed colour: the outline is near-white,
+       which vanished against the light day-mode thumbnail background. This
+       flips to near-black in day and near-white at night. */
+    accent: 'var(--numeral)',
+    /* WeatherTech Raceway Laguna Seca. Traced from the IndyCar track outline:
+       the PNG was decoded with alpha composited onto white, the infield
+       flood-filled, and its boundary followed and simplified to 33 points. */
+    svg: '<path d="M35.6,4.0 L37.9,4.4 L46.3,12.2 L46.8,14.2 L45.8,15.8 L39.9,17.9 L34.0,23.3 L33.4,25.8 L35.4,31.2 L37.4,33.7 L39.7,34.0 L42.4,32.6 L45.6,28.3 L46.1,28.3 L46.1,29.2 L45.2,30.5 L40.8,34.0 L35.0,36.0 L22.0,36.0 L21.6,35.6 L21.8,34.6 L24.3,28.7 L24.5,27.1 L23.2,25.5 L18.4,22.4 L17.2,20.4 L17.9,19.4 L22.5,16.2 L23.1,15.1 L22.9,13.1 L23.2,12.8 L25.7,11.5 L35.6,4.0 Z" stroke-width="2.2"/>'
   },
   night: {
     label: 'Night Run',
     accent: '#6fa8c5',
-    svg: '<path d="M38 8a14 14 0 1 0 12 21A15 15 0 0 1 38 8z"/><path d="M16 12l1.2 3.2L20.4 16l-3.2 1.2L16 20l-1.2-2.8L11.6 16l3.2-.8z"/><path d="M22 26l.8 2 2 .8-2 .8L22 32l-.8-2.4-2-.8 2-.8z"/>'
+    svg: '<path d="M38 8a14 14 0 1 0 12 21A15 15 0 0 1 38 8z"/><path d="M16 12l1.2 3.2L20.4 16l-3.2 1.2L16 20l-1.2-2.8L11.6 16l3.2-.8z"/>'
   }
 };
+
 
 const ROAD_TYPES = ['Highway', 'Canyon', 'City', 'Backroad', 'Track', 'Parking Lot', 'Gravel', 'Rough'];
 
@@ -566,6 +573,28 @@ socket.on('config', (payload) => {
   renderGpsFields();
 });
 
+function fmtBytes(b) {
+  if (typeof b !== 'number') return '--';
+  const gb = b / 1073741824;
+  if (gb >= 1) return `${gb.toFixed(gb >= 10 ? 0 : 1)} GB`;
+  return `${Math.max(1, Math.round(b / 1048576))} MB`;
+}
+
+socket.on('logs:storage', (s) => {
+  const fill = document.getElementById('storage-fill');
+  const text = document.getElementById('storage-text');
+  if (!fill || !text) return;
+  if (!s) {
+    text.innerText = 'Storage unavailable';
+    return;
+  }
+  fill.style.width = `${Math.min(100, s.usedPercent)}%`;
+  /* warn before the card fills: a full disk stops a recording mid-drive */
+  fill.classList.toggle('warn', s.usedPercent >= 85);
+  text.innerHTML = `<b>${fmtBytes(s.freeBytes)}</b> free of ${fmtBytes(s.totalBytes)}
+    &middot; logs ${fmtBytes(s.logsBytes)} &middot; ${s.usedPercent}% used`;
+});
+
 socket.on('logs:error', (payload) => {
   const toast = document.getElementById('toast');
   toast.innerText = payload.message;
@@ -586,6 +615,7 @@ socket.on('logs:error', (payload) => {
 document.addEventListener('DOMContentLoaded', () => {
   refresh();
   socket.emit('logs:state');
+  socket.emit('logs:storage');
 });
 
 refresh();

--- a/Source/main.js
+++ b/Source/main.js
@@ -78,6 +78,7 @@ function settingsPayload() {
     axes: config.axes || analysis.DEFAULT_AXES,
     settings: { ...DEFAULT_SETTINGS, ...(config.settings || {}) },
     theme: config.theme || { mode: 'auto' },
+    branding: { brand: 'eva', accent: 'default', ...(config.branding || {}) },
     vehicle: config.vehicle || { tireFactor: 1 }
   };
 }
@@ -156,6 +157,58 @@ function onImuData(data) {
       console.error('Error parsing IMU sample:', e.message);
     }
   });
+}
+
+const lightsScriptPath = path.join(sourceDir, 'lights.py');
+let lightsProcess = null;
+let lightsBackend = null;
+
+const DEFAULT_LIGHTS = { r: 0, g: 0, b: 0, brightness: 100 };
+
+function lightsState() {
+  return { ...DEFAULT_LIGHTS, ...(config.lights || {}) };
+}
+
+function startLights() {
+  if (lightsProcess) return;
+  try {
+    lightsProcess = spawn(resolvePython(), [lightsScriptPath]);
+  } catch (e) {
+    console.error('Could not start lights helper:', e.message);
+    return;
+  }
+  let buf = '';
+  lightsProcess.stdout.on('data', (data) => {
+    buf += data.toString();
+    const lines = buf.split('\n');
+    buf = lines.pop();
+    for (const line of lines) {
+      if (!line.trim().startsWith('{')) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.event === 'ready') {
+          lightsBackend = msg.backend;
+          console.log('Lights backend:', msg.backend || 'none');
+          /* restore the colour the car was left on */
+          sendLights(lightsState());
+        }
+        if (msg.event === 'error') console.error('Lights:', msg.message);
+      } catch (e) {
+        /* ignore malformed line */
+      }
+    }
+  });
+  lightsProcess.stderr.on('data', (d) => console.error('Lights stderr:', d.toString().trim()));
+  lightsProcess.on('close', () => { lightsProcess = null; lightsBackend = null; });
+}
+
+function sendLights(payload) {
+  if (!lightsProcess) return;
+  try {
+    lightsProcess.stdin.write(JSON.stringify(payload) + '\n');
+  } catch (e) {
+    console.error('Lights write failed:', e.message);
+  }
 }
 
 /* Deferred rather than started at require time. resolvePython() probes with
@@ -308,8 +361,13 @@ io.on('connection', (socket) => {
     }
   };
 
+  socket.on('logs:storage', guard(() => {
+    socket.emit('logs:storage', recorder.storage());
+  }));
+
   socket.on('logs:list', guard((payload) => {
     socket.emit('logs:listing', recorder.list(payload.path || ''));
+    socket.emit('logs:storage', recorder.storage());
   }));
 
   socket.on('logs:mkdir', guard((payload) => {
@@ -320,11 +378,13 @@ io.on('connection', (socket) => {
   socket.on('logs:rename', guard((payload) => {
     recorder.rename(payload.path, payload.name);
     socket.emit('logs:listing', recorder.list(payload.parent || ''));
+    socket.emit('logs:storage', recorder.storage());
   }));
 
   socket.on('logs:delete', guard((payload) => {
     recorder.remove(payload.path);
     socket.emit('logs:listing', recorder.list(payload.parent || ''));
+    socket.emit('logs:storage', recorder.storage());
   }));
 
   socket.on('logs:start', guard((payload) => {
@@ -353,6 +413,7 @@ io.on('connection', (socket) => {
   socket.on('logs:move', guard((payload) => {
     recorder.move(payload.path, payload.dest);
     socket.emit('logs:listing', recorder.list(payload.parent || ''));
+    socket.emit('logs:storage', recorder.storage());
   }));
 
   socket.on('logs:folders', guard(() => {
@@ -466,6 +527,53 @@ io.on('connection', (socket) => {
     socket.emit('bt:volume', { percent: v });
   }));
 
+  socket.on('lights:set', guard((payload) => {
+    const next = { ...lightsState() };
+    for (const key of ['r', 'g', 'b', 'brightness']) {
+      if (payload[key] !== undefined) {
+        const n = Number(payload[key]);
+        if (isFinite(n)) next[key] = Math.max(0, Math.min(key === 'brightness' ? 100 : 255, Math.round(n)));
+      }
+    }
+    sendLights(next);
+    /* persisted immediately so the strip comes back to the same colour after
+       an ignition cycle rather than defaulting to off */
+    config = { ...config, lights: next };
+    saveConfig(config);
+    io.emit('lights:state', { ...next, backend: lightsBackend });
+  }));
+
+  socket.on('lights:get', guard(() => {
+    socket.emit('lights:state', { ...lightsState(), backend: lightsBackend });
+  }));
+
+  socket.on('settings:accent', guard((payload) => {
+    const accent = ['purple', 'green'].includes(payload.accent) ? payload.accent : 'default';
+    config = { ...config, branding: { ...(config.branding || {}), accent } };
+    saveConfig(config);
+    io.emit('config', settingsPayload());
+    /* applied before first paint, so it needs a reload to take effect */
+    for (const win of BrowserWindow.getAllWindows()) {
+      const u = new URL(win.webContents.getURL());
+      u.searchParams.set('accent', accent);
+      win.loadURL(u.toString());
+    }
+  }));
+
+  socket.on('settings:brand', guard((payload) => {
+    const brand = payload.brand === 'jarvis' ? 'jarvis' : 'eva';
+    config = { ...config, branding: { brand } };
+    saveConfig(config);
+    io.emit('config', settingsPayload());
+    /* the brand is applied before first paint, so it only takes effect on a
+       reload - do that for the user rather than leaving a half-changed UI */
+    for (const win of BrowserWindow.getAllWindows()) {
+      const u = new URL(win.webContents.getURL());
+      u.searchParams.set('brand', brand);
+      win.loadURL(u.toString());
+    }
+  }));
+
   socket.on('settings:theme', guard((payload) => {
     const mode = ['auto', 'day', 'night'].includes(payload.mode) ? payload.mode : 'auto';
     config = { ...config, theme: { mode } };
@@ -505,6 +613,7 @@ io.on('connection', (socket) => {
     const result = recorder.purge(Number(payload.days) || 30);
     socket.emit('logs:purged', result);
     socket.emit('logs:listing', recorder.list(payload.parent || ''));
+    socket.emit('logs:storage', recorder.storage());
   }));
 
   socket.on('logs:analysis', guard(async (payload) => {
@@ -580,6 +689,20 @@ startBtPolling();
    is blocked on file:// URLs, and the socket config arrives well after the boot
    screen has already painted. The main process knows the answer synchronously,
    so hand it over in the URL and let themeBoot.js stamp it before first paint. */
+/* Defaults to EVA when unset, so the unit reverts on its own once the config
+   key is cleared - no code change needed to hand it back. */
+function bootBrand() {
+  const b = config.branding && config.branding.brand;
+  return b === 'jarvis' ? 'jarvis' : 'eva';
+}
+
+/* Accent sits on top of the brand palette. Absent config means "use the
+   brand's own accent", so clearing it is always safe. */
+function bootAccent() {
+  const a = config.branding && config.branding.accent;
+  return a === 'purple' || a === 'green' ? a : 'default';
+}
+
 function bootTheme() {
   const mode = (config.theme && config.theme.mode) || 'auto';
   if (mode === 'day' || mode === 'night') return mode;
@@ -608,7 +731,7 @@ const createWindow = () => {
 
   /* mode rides along so theme.js starts in the right state instead of
      assuming 'auto' and re-resolving to the wrong palette before config lands */
-  const query = { theme, mode };
+  const query = { theme, mode, brand: bootBrand(), accent: bootAccent() };
   /* hand over the fix too, so an 'auto' renderer resolves identically to main
      instead of falling back to 7am/7pm and disagreeing */
   const fix = gpsStatus.lastFix;
@@ -623,6 +746,7 @@ const createWindow = () => {
 app.whenReady().then(() => {
   createWindow();
   setTimeout(startImuLogger, IMU_START_DELAY_MS);
+  setTimeout(startLights, IMU_START_DELAY_MS + 400);
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/Source/settings.js
+++ b/Source/settings.js
@@ -50,7 +50,33 @@ document.getElementById('disappearAfter-slider').addEventListener('input', (even
   persistSetting('peakHold', event.target.value);
 });
 
+function setAccent(accent) {
+  socket.emit('settings:accent', { accent });
+}
+
+function renderAccent(accent) {
+  document.querySelectorAll('[data-accent-opt]').forEach((b) => {
+    b.classList.toggle('selected', b.dataset.accentOpt === (accent || 'default'));
+  });
+}
+
+function setBrand(brand) {
+  socket.emit('settings:brand', { brand });
+}
+
+function renderBrand(brand) {
+  const badge = document.getElementById('brand-state');
+  if (badge) badge.innerText = brand === 'jarvis' ? 'JARVIS' : 'EVA';
+  document.querySelectorAll('[data-brand-opt]').forEach((b) => {
+    b.classList.toggle('selected', b.dataset.brandOpt === brand);
+  });
+}
+
 socket.on('config', (payload) => {
+  if (payload && payload.branding) {
+    renderBrand(payload.branding.brand || 'eva');
+    renderAccent(payload.branding.accent || 'default');
+  }
   if (!payload || !payload.settings) return;
   const s = payload.settings;
   const apply = (id, valueId, value, digits) => {

--- a/Source/sliders.js
+++ b/Source/sliders.js
@@ -1,65 +1,77 @@
-// const downloadToFile = (content, filename, contentType) => {
-//     const a = document.createElement('a');
-//     const file = new Blob([content], {type: contentType});
-    
-//     a.href= URL.createObjectURL(file);
-//     a.download = filename;
-//     a.click();
-  
-//       URL.revokeObjectURL(a.href);
-//   };
-  
-//   document.querySelector('#btnSave').addEventListener('click', () => {
-//     const textArea = document.querySelector('textarea');
-    
-//     downloadToFile(textArea.value, 'my-new-file.txt', 'text/plain');
-//   });
+/* Lights tab: RGB sliders driving the strip over GPIO PWM.
+ *
+ * The previous version updated a CSS preview swatch and called updateData(),
+ * which was an empty stub - the sliders were not connected to anything.
+ */
 
+const rSlider = document.getElementById('redRange');
+const rOutput = document.getElementById('redVal');
+const gSlider = document.getElementById('greenRange');
+const gOutput = document.getElementById('greenVal');
+const bSlider = document.getElementById('blueRange');
+const bOutput = document.getElementById('blueVal');
 
+/* A drag fires oninput continuously. Sending every event would flood the
+   socket and the helper's stdin, so coalesce to one write per frame and always
+   send the final position. */
+let pendingLights = null;
+let lightsFrame = null;
 
-
-
-
-let data = "";
-
-function updateData() {
-    // data = rSlider.value + " " + gSlider.value + " " + bSlider.value;
-    // fs.writeFile('pytest.txt', data, (err) => {
-    //     if (err) throw err;
-    // })
-    const temp = "temp";
+function pushLights() {
+  lightsFrame = null;
+  if (!pendingLights) return;
+  socket.emit('lights:set', pendingLights);
+  pendingLights = null;
 }
 
-// Red Setup
-var rSlider = document.getElementById("redRange");
-var rOutput = document.getElementById("redVal");
-// Green Setup
-var gSlider = document.getElementById("greenRange");
-var gOutput = document.getElementById("greenVal");
-// Blue Setup
-var bSlider = document.getElementById("blueRange");
-var bOutput = document.getElementById("blueVal");
-
-// Red Output
-rOutput.innerHTML = rSlider.value;
-rSlider.oninput = function() {
-  rOutput.innerHTML = this.value;
-  document.documentElement.style.setProperty(`--redVal`, rSlider.value);
-  updateData();
+function queueLights(patch) {
+  pendingLights = { ...(pendingLights || {}), ...patch };
+  if (lightsFrame === null) lightsFrame = requestAnimationFrame(pushLights);
 }
 
-// Green Output
-gOutput.innerHTML = gSlider.value;
-gSlider.oninput = function() {
-  gOutput.innerHTML = this.value;
-  document.documentElement.style.setProperty(`--greenVal`, gSlider.value);
-  updateData();
+function paintSwatch() {
+  const root = document.documentElement.style;
+  root.setProperty('--redVal', rSlider.value);
+  root.setProperty('--greenVal', gSlider.value);
+  root.setProperty('--blueVal', bSlider.value);
 }
 
-// Blue Output
-bOutput.innerHTML = bSlider.value;
-bSlider.oninput = function() {
-  bOutput.innerHTML = this.value;
-  document.documentElement.style.setProperty(`--blueVal`, bSlider.value);
-  updateData();
+function bindChannel(slider, output, key) {
+  if (!slider || !output) return;
+  output.innerHTML = slider.value;
+  slider.oninput = function () {
+    output.innerHTML = this.value;
+    paintSwatch();
+    queueLights({ [key]: Number(this.value) });
+  };
 }
+
+bindChannel(rSlider, rOutput, 'r');
+bindChannel(gSlider, gOutput, 'g');
+bindChannel(bSlider, bOutput, 'b');
+
+/* Reflect whatever the strip is actually set to, including the colour restored
+   from config at boot - the sliders should never disagree with the hardware. */
+socket.on('lights:state', (state) => {
+  if (!state) return;
+  const set = (slider, output, value) => {
+    if (!slider || document.activeElement === slider) return;
+    slider.value = value;
+    if (output) output.innerHTML = value;
+  };
+  set(rSlider, rOutput, state.r);
+  set(gSlider, gOutput, state.g);
+  set(bSlider, bOutput, state.b);
+  paintSwatch();
+
+  const badge = document.getElementById('lights-backend');
+  if (badge) {
+    badge.innerText = state.backend ? state.backend : 'no GPIO';
+    badge.classList.toggle('warn', !state.backend);
+  }
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  paintSwatch();
+  socket.emit('lights:get');
+});

--- a/Source/styleEntry.css
+++ b/Source/styleEntry.css
@@ -133,3 +133,27 @@ body.error .dots i {
   border-color: #0a6e5c;
   color: #0a6e5c;
 }
+
+/* JARVIS keypad — warm palette */
+:root[data-brand="jarvis"] body {
+  background: radial-gradient(ellipse at 50% 40%, #1a1713 0%, #100e0b 70%);
+  color: #f4efe6;
+}
+:root[data-brand="jarvis"] .prompt { color: #9a8f80; }
+:root[data-brand="jarvis"] .dots i { border-color: #342d25; }
+:root[data-brand="jarvis"] .dots i.on {
+  background: #e0a94f;
+  border-color: #e0a94f;
+  box-shadow: 0 0 14px rgba(224, 169, 79, 0.5);
+}
+:root[data-brand="jarvis"] body.error .dots i { border-color: #f0655a; }
+:root[data-brand="jarvis"] #keyboard li {
+  color: #f4efe6;
+  background: #1a1713;
+  border-color: #342d25;
+}
+:root[data-brand="jarvis"] #keyboard li:active {
+  background: #241f1a;
+  border-color: #e0a94f;
+  color: #e0a94f;
+}

--- a/Source/styleGUI.css
+++ b/Source/styleGUI.css
@@ -15,10 +15,22 @@
 
   --teal: #3fd0b0;
   --teal-dim: #2a8c78;
-  --teal-glow: rgba(63, 208, 176, 0.35);
+  --teal-glow: rgba(var(--accent-rgb), 0.35);
 
   --orange: #ff7a33;
-  --orange-glow: rgba(255, 122, 51, 0.4);
+  --orange-glow: rgba(var(--warn-rgb), 0.4);
+
+  /* Accent and warning as raw channels, so translucent tints can be built from
+     them. Without these the sheet hardcodes EVA's teal and orange in ~28
+     places that no other brand can retint. */
+  --accent-rgb: 63, 208, 176;
+  --warn-rgb: 255, 122, 51;
+
+  /* The g-force needle is its own role: EVA draws it in the warning colour,
+     but a brand whose accent IS warm needs to decouple them. */
+  --needle: var(--orange);
+  --needle-tip: #ffb27a;
+  --needle-glow: var(--orange-glow);
 
   --rail: 6.4rem;
   --header: 2.6rem;
@@ -202,7 +214,7 @@ body {
 
 .sidenav button.active {
   color: var(--teal);
-  background: linear-gradient(90deg, rgba(63, 208, 176, 0.09), transparent);
+  background: linear-gradient(90deg, rgba(var(--accent-rgb), 0.09), transparent);
 }
 
 .sidenav button.active::before {
@@ -452,7 +464,7 @@ body {
   position: absolute;
   inset: 30%;
   border-radius: 50%;
-  border: 1px dashed rgba(63, 208, 176, 0.22);
+  border: 1px dashed rgba(var(--accent-rgb), 0.22);
 }
 
 .crosshair {
@@ -489,8 +501,8 @@ body {
 }
 
 .vector {
-  background: linear-gradient(to top, var(--orange), #ffb27a);
-  box-shadow: 0 0 1.2rem var(--orange-glow);
+  background: linear-gradient(to top, var(--needle), var(--needle-tip));
+  box-shadow: 0 0 1.2rem var(--needle-glow);
 }
 
 .peak-vector {
@@ -546,8 +558,8 @@ body {
 }
 
 #g-force-text {
-  color: var(--orange);
-  text-shadow: 0 0 1.4rem var(--orange-glow);
+  color: var(--needle);
+  text-shadow: 0 0 1.4rem var(--needle-glow);
 }
 
 #peak-text {
@@ -750,7 +762,7 @@ body {
 .primary-btn {
   border-color: var(--teal-dim);
   color: var(--teal);
-  background: rgba(63, 208, 176, 0.1);
+  background: rgba(var(--accent-rgb), 0.1);
 }
 
 .primary-btn.wide {
@@ -762,7 +774,7 @@ body {
 .stop-btn {
   border-color: #7a3326;
   color: var(--orange);
-  background: rgba(255, 122, 51, 0.1);
+  background: rgba(var(--warn-rgb), 0.1);
 }
 
 .rec-dot {
@@ -789,7 +801,7 @@ body {
   margin-bottom: 1rem;
   border-radius: 0.6rem;
   border: 1px solid #7a3326;
-  background: linear-gradient(90deg, rgba(255, 122, 51, 0.14), transparent);
+  background: linear-gradient(90deg, rgba(var(--warn-rgb), 0.14), transparent);
 }
 
 .rec-banner.active {
@@ -860,8 +872,8 @@ body {
 }
 
 .thumb svg {
-  width: 60%;
-  height: 60%;
+  width: 74%;
+  height: 74%;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.6;
@@ -993,7 +1005,7 @@ textarea.text-input {
 .check-row input {
   width: 1.1rem;
   height: 1.1rem;
-  accent-color: #3fd0b0;
+  accent-color: var(--teal);
 }
 
 .thumb-picker {
@@ -1019,19 +1031,35 @@ textarea.text-input {
   overflow: hidden;
 }
 
+/* The picker is a deliberate choice the user makes once per log, so the art
+   needs to be legible - 3.4rem at 60% fill rendered these near-unreadable. */
 .thumb-option .thumb {
-  height: 3.4rem;
+  height: 9rem;
+  padding: 0.6rem;
   background: transparent;
   border: 0;
 }
 
 .thumb-option span {
-  padding-bottom: 0.45rem;
+  padding-bottom: 0.7rem;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+/* Scoped to the picker: log cards keep the smaller fill, but here the icon
+   should use nearly the whole tile. */
+.thumb-option .thumb svg {
+  width: 100%;
+  height: 100%;
+}
+
+.thumb-picker {
+  gap: 0.9rem;
 }
 
 .thumb-option.selected {
   border-color: var(--teal);
-  background: rgba(63, 208, 176, 0.08);
+  background: rgba(var(--accent-rgb), 0.08);
   color: var(--teal);
 }
 
@@ -1057,7 +1085,7 @@ textarea.text-input {
 .road-chip.selected {
   border-color: var(--teal);
   color: var(--teal);
-  background: rgba(63, 208, 176, 0.1);
+  background: rgba(var(--accent-rgb), 0.1);
 }
 
 .modal-buttons {
@@ -1157,7 +1185,7 @@ textarea.text-input {
 .osk-key.accent {
   border-color: var(--teal-dim);
   color: var(--teal);
-  background: rgba(63, 208, 176, 0.12);
+  background: rgba(var(--accent-rgb), 0.12);
 }
 
 .osk-key.active {
@@ -1181,7 +1209,7 @@ body.osk-open .settings-card {
 
 .log-card.entry.selected {
   border-color: var(--teal);
-  background: rgba(63, 208, 176, 0.06);
+  background: rgba(var(--accent-rgb), 0.06);
 }
 
 .log-card .thumb {
@@ -1223,7 +1251,7 @@ body.osk-open .settings-card {
 .card-actions button.view {
   border-color: var(--teal-dim);
   color: var(--teal);
-  background: rgba(63, 208, 176, 0.1);
+  background: rgba(var(--accent-rgb), 0.1);
 }
 
 .detail-hero {
@@ -1322,7 +1350,7 @@ body.osk-open .settings-card {
 
 .folder-tile.selected {
   border-color: var(--teal);
-  background: rgba(63, 208, 176, 0.06);
+  background: rgba(var(--accent-rgb), 0.06);
 }
 
 .folder-open {
@@ -1454,7 +1482,7 @@ body.osk-open .settings-card {
 .dtab.active {
   border-color: var(--teal);
   color: var(--teal);
-  background: rgba(63, 208, 176, 0.1);
+  background: rgba(var(--accent-rgb), 0.1);
 }
 
 .stat-row {
@@ -1531,11 +1559,11 @@ body.osk-open .settings-card {
 .ch-chip.on {
   border-color: var(--teal);
   color: var(--teal);
-  background: rgba(63, 208, 176, 0.14);
+  background: rgba(var(--accent-rgb), 0.14);
 }
 
 :root[data-theme="day"] .ch-chip.on {
-  background: rgba(10, 110, 92, 0.16);
+  background: rgba(var(--accent-rgb), 0.16);
 }
 
 .ch-legend {
@@ -1679,7 +1707,7 @@ body.osk-open .settings-card {
   margin-bottom: 1rem;
   border-radius: 0.5rem;
   border: 1px solid var(--teal-dim);
-  background: rgba(63, 208, 176, 0.08);
+  background: rgba(var(--accent-rgb), 0.08);
   font-size: 0.85rem;
   line-height: 1.5;
   color: var(--silver);
@@ -1693,7 +1721,7 @@ body.osk-open .settings-card {
 
 .calib-warning.error {
   border-color: #7a3326;
-  background: rgba(255, 122, 51, 0.08);
+  background: rgba(var(--warn-rgb), 0.08);
 }
 
 .calib-warning.error b {
@@ -1767,7 +1795,7 @@ body.osk-open .settings-card {
   display: block;
   height: 100%;
   width: 0;
-  background: linear-gradient(90deg, var(--orange), #ffb27a);
+  background: linear-gradient(90deg, var(--needle), var(--needle-tip));
   animation-name: fillbar;
   animation-timing-function: linear;
   animation-fill-mode: forwards;
@@ -1980,7 +2008,7 @@ body.osk-open .settings-card {
   padding: 1rem;
   border-radius: 0.5rem;
   border: 1px solid var(--teal-dim);
-  background: rgba(63, 208, 176, 0.08);
+  background: rgba(var(--accent-rgb), 0.08);
   font-size: 1rem;
   line-height: 1.6;
   color: var(--numeral);
@@ -2014,13 +2042,13 @@ button.pill {
 
 .obd-status.ready {
   border-color: var(--teal-dim);
-  background: rgba(63, 208, 176, 0.08);
+  background: rgba(var(--accent-rgb), 0.08);
 }
 
 .obd-status.error,
 .obd-status.unavailable {
   border-color: #7a3326;
-  background: rgba(255, 122, 51, 0.07);
+  background: rgba(var(--warn-rgb), 0.07);
 }
 
 .obd-state {
@@ -2122,7 +2150,7 @@ button.pill {
   padding: 1.2rem;
   border-radius: 0.5rem;
   border: 1px solid var(--teal-dim);
-  background: rgba(63, 208, 176, 0.08);
+  background: rgba(var(--accent-rgb), 0.08);
   font-size: 1.1rem;
   color: var(--teal);
   text-align: center;
@@ -2164,7 +2192,7 @@ button.pill {
 .pid-chip.selected {
   border-color: var(--teal);
   color: var(--teal);
-  background: rgba(63, 208, 176, 0.1);
+  background: rgba(var(--accent-rgb), 0.1);
 }
 
 .pid-budget {
@@ -2202,11 +2230,11 @@ button.pill {
   font-size: 1.05rem;
   line-height: 1.5;
   border: 1px solid var(--teal-dim);
-  background: rgba(63, 208, 176, 0.08);
+  background: rgba(var(--accent-rgb), 0.08);
   color: var(--silver);
 }
 
-.verdict.warn { border-color: #7a3326; background: rgba(255, 122, 51, 0.1); }
+.verdict.warn { border-color: #7a3326; background: rgba(var(--warn-rgb), 0.1); }
 .verdict.watch { border-color: var(--line); background: var(--surface-2); }
 
 .trend { display: flex; align-items: flex-end; gap: 0.4rem; height: 8rem; }
@@ -2225,6 +2253,8 @@ button.pill {
 .trend-bar em { font-style: normal; font-size: 0.65rem; color: var(--silver-dim); }
 
 :root[data-theme="day"] {
+  --accent-rgb: 10, 110, 92;
+  --warn-rgb: 152, 58, 11;
   --bg: #d3d9db;
   --surface: #ffffff;
   --surface-2: #e7ecee;
@@ -2237,7 +2267,7 @@ button.pill {
 
   --teal: #0a6e5c;
   --teal-dim: #0d8f78;
-  --teal-glow: rgba(10, 110, 92, 0.28);
+  --teal-glow: rgba(var(--accent-rgb), 0.28);
 
   --orange: #983a0b;
   --orange-glow: rgba(152, 58, 11, 0.28);
@@ -2249,7 +2279,7 @@ button.pill {
 }
 
 :root[data-theme="day"] .gauge::after {
-  border-color: rgba(10, 110, 92, 0.3);
+  border-color: rgba(var(--accent-rgb), 0.3);
 }
 
 :root[data-theme="day"] .statusbar {
@@ -2257,11 +2287,11 @@ button.pill {
 }
 
 :root[data-theme="day"] .sidenav button.active {
-  background: linear-gradient(90deg, rgba(10, 110, 92, 0.14), transparent);
+  background: linear-gradient(90deg, rgba(var(--accent-rgb), 0.14), transparent);
 }
 
 :root[data-theme="day"] .primary-btn {
-  background: rgba(10, 110, 92, 0.12);
+  background: rgba(var(--accent-rgb), 0.12);
 }
 
 :root[data-theme="day"] .danger-btn,
@@ -2298,7 +2328,7 @@ button.pill {
 }
 
 :root[data-theme="day"] .sidenav button.active {
-  background: linear-gradient(90deg, rgba(10, 110, 92, 0.18), transparent);
+  background: linear-gradient(90deg, rgba(var(--accent-rgb), 0.18), transparent);
 }
 
 :root[data-theme="day"] .slider::-webkit-slider-thumb,
@@ -2325,7 +2355,7 @@ button.pill {
 :root[data-theme="day"] .verdict,
 :root[data-theme="day"] .calib-warning,
 :root[data-theme="day"] .export-ok {
-  background: rgba(10, 110, 92, 0.14);
+  background: rgba(var(--accent-rgb), 0.14);
   border-color: var(--teal);
 }
 
@@ -2348,11 +2378,11 @@ button.pill {
 .theme-option.selected {
   border-color: var(--teal);
   color: var(--teal);
-  background: rgba(63, 208, 176, 0.12);
+  background: rgba(var(--accent-rgb), 0.12);
 }
 
 :root[data-theme="day"] .theme-option.selected {
-  background: rgba(10, 110, 92, 0.18);
+  background: rgba(var(--accent-rgb), 0.18);
   border-color: var(--teal);
 }
 
@@ -2462,7 +2492,7 @@ button.pill {
   height: 5.6rem;
   border-color: var(--teal);
   color: var(--teal);
-  background: rgba(63, 208, 176, 0.12);
+  background: rgba(var(--accent-rgb), 0.12);
 }
 
 .vol-row {
@@ -2560,3 +2590,165 @@ button.pill {
 .vol-row { max-width: 34rem; margin-top: 1.6vh; flex: 0 0 auto; }
 .track-bar, .track-times { max-width: 42rem; }
 .track-bar { margin-top: 1vh; }
+
+/* ---- Storage readout in the logs header ---- */
+.storage-bar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 0 0.9rem;
+  border-bottom: 1px solid var(--line-soft);
+  margin-bottom: 0.9rem;
+}
+
+.storage-track {
+  flex: 0 0 22rem;
+  height: 0.6rem;
+  border-radius: 0.3rem;
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  overflow: hidden;
+}
+
+.storage-track i {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: var(--teal);
+  transition: width 0.3s ease;
+}
+
+.storage-track i.warn { background: var(--orange); }
+
+.storage-text {
+  font-size: 0.95rem;
+  color: var(--silver-dim);
+}
+
+.storage-text b { color: var(--numeral); font-weight: 500; }
+
+/* ============================================================
+   JARVIS — Morgane's build.
+   Her car is white over a beige interior, so the palette runs warm:
+   amber instead of teal, and warm neutrals instead of the cool
+   near-blacks EVA uses to sit against a black interior.
+   Every value below is verified to WCAG AA against its background.
+   ============================================================ */
+:root[data-brand="jarvis"] {
+  --bg: #100e0b;
+  --surface: #1a1713;
+  --surface-2: #241f1a;
+  --line: #342d25;
+  --line-soft: #26201a;
+
+  --silver: #d8cfc2;
+  --silver-dim: #9a8f80;
+  --numeral: #f4efe6;
+
+  /* Hot Rod red takes the accent role teal holds in EVA */
+  --teal: #e8503a;
+  --teal-dim: #d15a40;
+  --teal-glow: rgba(232, 80, 58, 0.35);
+
+  /* With a red accent the warning moves to amber. A red-on-red warning would
+     not register as an alert at all. */
+  --orange: #e0a94f;
+  --orange-glow: rgba(224, 169, 79, 0.4);
+
+  --accent-rgb: 232, 80, 58;
+  --warn-rgb: 224, 169, 79;
+
+  /* the g-force needle follows the accent here, not the warning colour */
+  --needle: #e8503a;
+  --needle-tip: #ff9c86;
+  --needle-glow: rgba(232, 80, 58, 0.45);
+}
+
+:root[data-brand="jarvis"][data-theme="day"] {
+  --bg: #e6e0d6;
+  --surface: #fffdf8;
+  --surface-2: #efe9de;
+  --line: #a1968a;
+  --line-soft: #c4bbae;
+
+  --silver: #453c30;
+  --silver-dim: #6b6053;
+  --numeral: #14100b;
+
+  --teal: #8e2410;
+  --teal-dim: #a8331a;
+  --teal-glow: rgba(142, 36, 16, 0.28);
+
+  --orange: #7d5010;
+  --orange-glow: rgba(125, 80, 16, 0.28);
+
+  --accent-rgb: 142, 36, 16;
+  --warn-rgb: 125, 80, 16;
+
+  --needle: #8e2410;
+  --needle-tip: #c0503a;
+  --needle-glow: rgba(142, 36, 16, 0.35);
+}
+
+/* accent-tinted surfaces are defined against teal literals in the base sheet,
+   so they need warm equivalents here */
+:root[data-brand="jarvis"] .sidenav button.active {
+  background: linear-gradient(90deg, rgba(232, 80, 58, 0.12), transparent);
+}
+:root[data-brand="jarvis"] .theme-option.selected,
+:root[data-brand="jarvis"] .ch-chip.on {
+  background: rgba(232, 80, 58, 0.16);
+}
+:root[data-brand="jarvis"][data-theme="day"] .sidenav button.active {
+  background: linear-gradient(90deg, rgba(142, 36, 16, 0.16), transparent);
+}
+:root[data-brand="jarvis"][data-theme="day"] .theme-option.selected,
+:root[data-brand="jarvis"][data-theme="day"] .ch-chip.on {
+  background: rgba(142, 36, 16, 0.16);
+}
+
+/* ============================================================
+   Accent themes — selectable in Settings > Display.
+   Layered ON TOP of the brand palette: the brand decides the base
+   surfaces, the accent decides the highlight colour. Absent or
+   unrecognised resolves to the brand's own accent.
+   ============================================================ */
+:root[data-accent="purple"] {
+  --teal: #a56ee0;
+  --teal-dim: #b98cea;
+  --teal-glow: rgba(165, 110, 224, 0.35);
+  --accent-rgb: 165, 110, 224;
+  --needle: #a56ee0;
+  --needle-tip: #c9a8f0;
+  --needle-glow: rgba(165, 110, 224, 0.45);
+}
+
+:root[data-accent="purple"][data-theme="day"] {
+  --teal: #553091;
+  --teal-dim: #6a3fae;
+  --teal-glow: rgba(85, 48, 145, 0.28);
+  --accent-rgb: 85, 48, 145;
+  --needle: #553091;
+  --needle-tip: #8a63c4;
+  --needle-glow: rgba(85, 48, 145, 0.35);
+}
+
+:root[data-accent="green"] {
+  --teal: #4fc98a;
+  --teal-dim: #6fd8a1;
+  --teal-glow: rgba(79, 201, 138, 0.35);
+  --accent-rgb: 79, 201, 138;
+  --needle: #4fc98a;
+  --needle-tip: #9ce8c1;
+  --needle-glow: rgba(79, 201, 138, 0.45);
+}
+
+:root[data-accent="green"][data-theme="day"] {
+  --teal: #136b42;
+  --teal-dim: #1a8a55;
+  --teal-glow: rgba(19, 107, 66, 0.28);
+  --accent-rgb: 19, 107, 66;
+  --needle: #136b42;
+  --needle-tip: #3fa06f;
+  --needle-glow: rgba(19, 107, 66, 0.35);
+}

--- a/Source/styleWelcome.css
+++ b/Source/styleWelcome.css
@@ -23,7 +23,8 @@ body {
 
 .mark {
   font-size: 12vw;
-  font-weight: 200;
+  /* bold rather than hairline - reads with more presence at a glance */
+  font-weight: 700;
   line-height: 1;
   letter-spacing: 0.4em;
   margin-right: -0.4em;
@@ -96,29 +97,117 @@ body {
 
 /* Day mode: the boot sequence keeps its shape but inverts, so a daylight boot
    never flashes a near-black screen. Accents darken to stay legible on light. */
+/* EVA's boot screen is night-only in both themes: the dark version reads
+   better, and the handoff veil below carries it into a light interface
+   without the boot screen itself having to lighten. */
 :root[data-theme="day"] body {
-  background: radial-gradient(ellipse at 50% 45%, #ffffff 0%, #d3d9db 65%);
-  color: #0b1013;
+  background: radial-gradient(ellipse at 50% 45%, #14181a 0%, #0b0d0e 65%);
+  color: #e9edee;
 }
 
 :root[data-theme="day"] .mark {
-  color: #0a6e5c;
-  text-shadow: 0 0 4vw rgba(10, 110, 92, 0.25);
+  color: #3fd0b0;
+  text-shadow: 0 0 4vw rgba(63, 208, 176, 0.45);
 }
 
-:root[data-theme="day"] .typewriter {
-  color: #4a575d;
-}
-
-:root[data-theme="day"] .typewriter::after {
-  background: #0a6e5c;
-}
-
-:root[data-theme="day"] .boot-bar {
-  background: #b6bfc2;
-}
+:root[data-theme="day"] .typewriter { color: #b7babc; }
+:root[data-theme="day"] .typewriter::after { background: #3fd0b0; }
+:root[data-theme="day"] .boot-bar { background: #1c2124; }
 
 :root[data-theme="day"] .boot-bar::after {
-  background: linear-gradient(90deg, #0d8f78, #0a6e5c);
-  box-shadow: 0 0 1vw rgba(10, 110, 92, 0.4);
+  background: linear-gradient(90deg, #2a8c78, #3fd0b0);
+  box-shadow: 0 0 1vw rgba(63, 208, 176, 0.6);
 }
+
+/* ============================================================
+   JARVIS boot sequence — Hot Rod red, Terminal mono, soft aura.
+
+   Deliberately NIGHT-ONLY, in both themes: the dark boot screen simply
+   looks better, and the jump to a light interface is handled by the
+   handoff veil below rather than by lightening the boot screen itself.
+   ============================================================ */
+:root[data-brand="jarvis"] body,
+:root[data-brand="jarvis"][data-theme="day"] body {
+  background: radial-gradient(ellipse at 50% 45%, #1c0f0c 0%, #0e0605 65%);
+  color: #e6c9a8;
+}
+
+:root[data-brand="jarvis"] .mark,
+:root[data-brand="jarvis"][data-theme="day"] .mark {
+  font-family: ui-monospace, "DejaVu Sans Mono", Menlo, monospace;
+  font-weight: 300;
+  font-size: 9.5vw;
+  letter-spacing: 0.35em;
+  /* letter-spacing also trails the final glyph, which pushes the word left of
+     centre - cancel exactly one tracking unit */
+  margin-right: -0.35em;
+  color: #e8503a;
+  text-shadow: 0 0 4vw rgba(232, 80, 58, 0.5);
+  /* pure opacity fade, no movement */
+  opacity: 0;
+  animation: jfade 2.1s ease-in-out forwards;
+}
+
+:root[data-brand="jarvis"] .typewriter,
+:root[data-brand="jarvis"][data-theme="day"] .typewriter {
+  font-family: ui-monospace, "DejaVu Sans Mono", Menlo, monospace;
+  font-weight: 300;
+  font-size: 1.9vw;
+  letter-spacing: 0.14em;
+  margin-right: -0.14em;
+  color: #e6c9a8;
+  /* the base EVA rule types this in; JARVIS fades instead */
+  clip-path: none;
+  opacity: 0;
+  /* starts only once the wordmark has fully resolved */
+  animation: jfade 2.1s ease-in-out 2.1s forwards;
+}
+
+:root[data-brand="jarvis"] .typewriter::after,
+:root[data-brand="jarvis"][data-theme="day"] .typewriter::after {
+  display: none;                 /* no typing caret when fading */
+}
+
+:root[data-brand="jarvis"] .boot-bar,
+:root[data-brand="jarvis"][data-theme="day"] .boot-bar {
+  background: #26120e;
+  opacity: 0;
+  animation: jfade 1.4s ease-in-out 3.6s forwards;
+}
+
+:root[data-brand="jarvis"] .boot-bar::after,
+:root[data-brand="jarvis"][data-theme="day"] .boot-bar::after {
+  background: linear-gradient(90deg, #a33422, #e8503a);
+  box-shadow: 0 0 1vw rgba(232, 80, 58, 0.6);
+  animation: fill 5s ease-in-out forwards;
+}
+
+@keyframes jfade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ---- handoff ----
+   A solid panel the exact colour of the interface's empty space fades over
+   the boot screen, and only once it is fully opaque does the app navigate.
+   The interface therefore appears behind a background that already matches,
+   so there is no flash between the two.
+
+   It is a separate element rather than a transition on body: the boot screen
+   uses a gradient background, and gradients cannot animate to a flat colour. */
+:root { --handoff-bg: #0b0d0e; }
+:root[data-theme="day"] { --handoff-bg: #d3d9db; }
+:root[data-brand="jarvis"] { --handoff-bg: #100e0b; }
+:root[data-brand="jarvis"][data-theme="day"] { --handoff-bg: #e6e0d6; }
+
+.handoff-veil {
+  position: fixed;
+  inset: 0;
+  background: var(--handoff-bg);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 10;
+  transition: opacity 0.85s ease-in-out;
+}
+
+body.handoff .handoff-veil { opacity: 1; }

--- a/Source/welcomeMessage.html
+++ b/Source/welcomeMessage.html
@@ -5,18 +5,36 @@
     <link rel="stylesheet" href="styleWelcome.css">
     <script src="daylight.js"></script>
     <script src="themeBoot.js"></script>
+    <script src="branding.js"></script>
 </head>
 <body onload="loadUp()">
-    <div class="mark">EVA</div>
-    <div class="typewriter">Welcome, Alex</div>
+    <div class="mark" data-brand-name>EVA</div>
+    <div class="typewriter" data-brand-greeting>Hello, Morgane</div>
     <div class="boot-bar"></div>
 
+    <!-- fades in over the boot screen in the interface's own background
+         colour, so the handoff has nothing to flash against -->
+    <div class="handoff-veil"></div>
+
     <script type="text/javascript">
+        /* The wordmark resolves over 2.1s, then the greeting over the next
+           2.1s, then the bar. The veil starts once all three have landed. */
+        var HANDOFF_AT_MS = 4900;   // begin fading to the interface colour
+        var VEIL_MS       = 850;    // must match the CSS transition
+
         function loadUp() {
-                setTimeout(swapGUI, 3500);
-            }
+            setTimeout(startHandoff, HANDOFF_AT_MS);
+        }
+
+        function startHandoff() {
+            document.body.classList.add('handoff');
+            /* navigate only once the veil is fully opaque - the interface then
+               paints behind a background that already matches it */
+            setTimeout(swapGUI, VEIL_MS);
+        }
+
         function swapGUI() {
-            // carry ?theme= forward so gui.html paints in the right palette
+            // carry ?theme=, ?mode= and ?brand= forward so gui.html paints correctly
             window.location = "gui.html" + window.location.search;
         }
     </script>


### PR DESCRIPTION
The brand-agnostic half of Morgane's JARVIS work, ported to EVA. The JARVIS palette rides along but is **dormant** — it only activates on `data-brand="jarvis"`, and the brand resolves to `eva` when config is absent. EVA's appearance is unchanged except where noted below.

## Fixes that apply to EVA too

- **The Lights tab did nothing.** `sliders.js` called an empty `updateData()` stub and `lights_control.py` targeted a Windows COM port. `lights.py` replaces it with real PWM on GPIO 12/13/19 — chosen to avoid GPIO 18's conflict with onboard audio and the IMU's I2C bus. Colour persists on change and restores at boot. Needs three MOSFETs wired up; see `LED-WIRING.md`.
- **The log thumbnail picker** was 3.4rem tall with art filling 60% of it, leaving the choices nearly unreadable on a 1080p panel.
- **34 hardcoded teal and orange literals** that no brand could override now resolve through `--accent-rgb` / `--warn-rgb`, and the g-force gauge has its own `--needle` role. Rendering is identical — retinting just no longer means hunting literals.
- **pigpio's stdout banner** corrupted the helper's JSON stream, the same failure the IMU logger had.

## New

- **Redrawn log thumbnails** sharing a stroke weight and subject family, including a traced Laguna Seca circuit for Track Day
- **Speaker icon** for Music, **tachometer** promoted to Track
- **Purple and green accent themes** in Settings, layered on the brand
- **Boot handoff** — a veil in the interface's own background colour fades over the boot screen, and the app navigates only once it is opaque, so there is no flash between the two

## Alex's calls, suggested by Morgane

These are taste rather than fixes, hence a PR rather than a push:

- Greeting changed from "Welcome, Alex" to "Hello, Alex"
- Wordmark is **bold** in its original face rather than hairline
- Boot screen stays dark in both themes, with the handoff veil carrying it into the light interface

Revert any of the three and the rest still stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzukpXeqN5TsVzyHW4RZPG
